### PR TITLE
poll form and ability to create them added

### DIFF
--- a/src/components/CreatePoll.jsx
+++ b/src/components/CreatePoll.jsx
@@ -1,0 +1,113 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import PollForm from "./PollForm";
+import axios from "axios";
+
+const CreatePoll = () => {
+  const navigate = useNavigate();
+
+  const [pollData, setPollData] = useState({
+    title: "",
+    description: "",
+    allowGuests: false,
+    endTime: "",
+    options: [{ text: "" }, { text: "" }],
+    status: "draft",
+  });
+
+  const [createdPollId, setCreatedPollId] = useState(null);
+  const [message, setMessage] = useState("");
+
+  const handleFieldChange = (field, value) => {
+    setPollData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleOptionChange = (index, value) => {
+    const newOptions = [...pollData.options];
+    newOptions[index].text = value;
+    setPollData((prev) => ({ ...prev, options: newOptions }));
+  };
+
+  const addOption = () => {
+    setPollData((prev) => ({
+      ...prev,
+      options: [...prev.options, { text: "" }],
+    }));
+  };
+
+  const removeOption = (index) => {
+    const newOptions = [...pollData.options];
+    newOptions.splice(index, 1);
+    setPollData((prev) => ({ ...prev, options: newOptions }));
+  };
+
+  const createPoll = async () => {
+    const pollRes = await axios.post("/api/polls", {
+      title: pollData.title,
+      description: pollData.description,
+      allowGuests: pollData.allowGuests,
+      endTime: pollData.endTime || null,
+    });
+
+    const pollId = pollRes.data.id;
+    setCreatedPollId(pollId);
+
+    const validOptions = pollData.options.filter((opt) => opt.text.trim() !== "");
+    await Promise.all(
+      validOptions.map((opt) =>
+        axios.post(`/api/polls/${pollId}/options`, { text: opt.text })
+      )
+    );
+
+    return pollId;
+  };
+
+  const handleSaveAsDraft = async () => {
+    const confirmed = window.confirm("Save this poll as a draft?");
+    if (!confirmed) return;
+
+    try {
+      await createPoll();
+      setMessage("✅ Poll saved as draft!");
+    } catch {
+      setMessage("❌ Failed to save poll.");
+    }
+  };
+
+  const handlePublish = async () => {
+    const confirmed = window.confirm("Are you sure you want to publish this poll?");
+    if (!confirmed) return;
+
+    try {
+      const pollId = createdPollId || (await createPoll());
+      await axios.put(`/api/polls/publish/${pollId}`);
+      setMessage("🚀 Poll published!");
+      navigate(`/polls/${pollId}`);
+    } catch (err) {
+      console.error("Publish error:", err);
+      setMessage("❌ Failed to publish poll.");
+    }
+  };
+
+  return (
+    <div>
+      <h2>Create a New Poll</h2>
+      <PollForm
+        initialData={pollData}
+        status={pollData.status}
+        onChange={(updatedFields) =>
+          setPollData((prev) => ({ ...prev, ...updatedFields }))
+        }
+      />
+      {pollData.status === "draft" && (
+        <>
+          <button onClick={handleSaveAsDraft}>Save as Draft</button>
+          <button onClick={handlePublish}>Publish Poll</button>
+        </>
+      )}
+      {message && <p>{message}</p>}
+    </div>
+  );
+};
+
+export default CreatePoll;

--- a/src/components/PollForm.jsx
+++ b/src/components/PollForm.jsx
@@ -1,0 +1,122 @@
+import React, { useState, useEffect } from "react";
+
+const PollForm = ({ onSubmit, onChange, initialData = {}, status = "draft" }) => {
+  const [title, setTitle] = useState(initialData.title || "");
+  const [description, setDescription] = useState(initialData.description || "");
+  const [options, setOptions] = useState(
+    initialData.options?.map((opt) => (typeof opt === "string" ? opt : opt.text)) || ["", ""]
+  );
+  const [allowGuests, setAllowGuests] = useState(initialData.allowGuests || false);
+  const [endTime, setEndTime] = useState(initialData.endTime || "");
+
+  const isDisabled = status !== "draft";
+
+  useEffect(() => {
+    onChange?.({
+      title,
+      description,
+      options,
+      allowGuests,
+      endTime,
+    });
+  }, [title, description, options, allowGuests, endTime]);
+
+  const handleOptionChange = (value, index) => {
+    const updated = [...options];
+    updated[index] = value;
+    setOptions(updated);
+  };
+
+  const addOption = () => {
+    setOptions([...options, ""]);
+  };
+
+  const removeOption = (index) => {
+    if (options.length > 2) {
+      const updated = options.filter((_, i) => i !== index);
+      setOptions(updated);
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit?.({
+      title,
+      description,
+      options: options.filter((opt) => opt.trim() !== ""),
+      allowGuests,
+      endTime,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Title:
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+          disabled={isDisabled}
+        />
+      </label>
+
+      <label>
+        Description:
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          required
+          disabled={isDisabled}
+        />
+      </label>
+
+      <label>Options:</label>
+      {options.map((opt, idx) => (
+        <div key={idx}>
+          <input
+            value={opt}
+            onChange={(e) => handleOptionChange(e.target.value, idx)}
+            required
+            disabled={isDisabled}
+          />
+          <button
+            type="button"
+            onClick={() => removeOption(idx)}
+            disabled={isDisabled}
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+
+      <button type="button" onClick={addOption} disabled={isDisabled}>
+        Add Option
+      </button>
+
+      <label>
+        Allow Guest Voting:
+        <input
+          type="checkbox"
+          checked={allowGuests}
+          onChange={(e) => setAllowGuests(e.target.checked)}
+          disabled={isDisabled}
+        />
+      </label>
+
+      <label>
+        End Time:
+        <input
+          type="datetime-local"
+          value={endTime}
+          onChange={(e) => setEndTime(e.target.value)}
+          disabled={isDisabled}
+        />
+      </label>
+
+      <button type="submit" disabled={isDisabled}>Create Poll</button>
+    </form>
+  );
+};
+
+export default PollForm;


### PR DESCRIPTION
Notes:

    adds PollForm and CreatePoll components to support poll creation and publishing.
    Users can input a title, description, options (add/remove), toggle guest voting, and set an optional end time.
    The form is disabled after publishing to prevent edits.
    The CreatePoll page allows saving as a draft or publishing, with success/error messages and navigation to the final poll.
    It also supports duplication via passed initialData (and a shiny new button!).
    All changes sync with local state and submit to the backend using Axios.

